### PR TITLE
Use correct Print function to eliminate formatting warning

### DIFF
--- a/compiled_starters/git-starter-go/app/main.go
+++ b/compiled_starters/git-starter-go/app/main.go
@@ -14,12 +14,12 @@ func main() {
 	// case "init":
 	//     for _, dir := range []string{".git", ".git/objects", ".git/refs"} {
 	//         if err := os.Mkdir(dir, 0755); err != nil {
-	//             fmt.Println("Error creating directory: %s", err)
+	//             fmt.Printf("Error creating directory: %s\n", err)
 	//         }
 	//     }
 	//     headFileContents := []byte("ref: refs/heads/master\n")
 	//     if err := ioutil.WriteFile(".git/HEAD", headFileContents, 0644); err != nil {
-	// 	       fmt.Println("Error writing file: %s", err)
+	// 	       fmt.Printf("Error writing file: %s\n", err)
 	// 	   }
 	//     fmt.Println("Initialized git directory")
 	//

--- a/starter_templates/git/go/app/main.go
+++ b/starter_templates/git/go/app/main.go
@@ -14,12 +14,12 @@ func main() {
 	// case "init":
 	//     for _, dir := range []string{".git", ".git/objects", ".git/refs"} {
 	//         if err := os.Mkdir(dir, 0755); err != nil {
-	//             fmt.Println("Error creating directory: %s", err)
+	//             fmt.Printf("Error creating directory: %s\n", err)
 	//         }
 	//     }
 	//     headFileContents := []byte("ref: refs/heads/master\n")
 	//     if err := ioutil.WriteFile(".git/HEAD", headFileContents, 0644); err != nil {
-	// 	       fmt.Println("Error writing file: %s", err)
+	// 	       fmt.Printf("Error writing file: %s\n", err)
 	// 	   }
 	//     fmt.Println("Initialized git directory")
 	//


### PR DESCRIPTION
In go, you cant use a formatting directive (such as `%s`) in `fmt.Println()`. In the starter boilerplate I just used `fmt.Printf()` instead.