### PR TITLE
Remove solargraph from dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "colorize"
 gem "diffy"
 
 group :development do
-  gem "solargraph"
   gem "pry"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,68 +3,25 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.0)
-    backport (1.1.2)
-    benchmark (0.1.0)
     coderay (1.1.2)
     colorize (0.8.1)
     diffy (3.3.0)
-    e2mmap (0.1.0)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    jaro_winkler (1.5.4)
-    maruku (0.7.3)
     method_source (1.0.0)
-    mini_portile2 (2.4.0)
     minitest (5.14.0)
     multipart-post (2.1.1)
     mustache (1.1.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.19.1)
-    parser (2.7.0.5)
-      ast (~> 2.4.0)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.3)
-    rainbow (3.0.0)
-    reverse_markdown (1.4.0)
-      nokogiri
-    rexml (3.2.4)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.7.0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      rexml
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    solargraph (0.38.6)
-      backport (~> 1.1)
-      benchmark
-      bundler (>= 1.17.2)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      maruku (~> 0.7, >= 0.7.3)
-      nokogiri (~> 1.9, >= 1.9.1)
-      parser (~> 2.3)
-      reverse_markdown (~> 1.0, >= 1.0.5)
-      rubocop (~> 0.52)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9)
-    thor (1.0.1)
-    tilt (2.0.10)
-    unicode-display_width (1.6.1)
-    yard (0.9.24)
 
 PLATFORMS
   ruby
@@ -76,7 +33,6 @@ DEPENDENCIES
   mustache
   octokit
   pry
-  solargraph
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Solargraph is a language server for ruby and stuff around this should be
configured locally. So removing this.