### PR TITLE
Git - Kotlin Language Support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test_git_go: compile download_starter_testers
 test_git_rust: compile download_starter_testers
 	bundle exec ruby tests/test_all.rb git rust
 
+test_git_kotlin: compile download_starter_testers
+	bundle exec ruby tests/test_all.rb git kotlin
+
 test_docker_go: compile download_starter_testers
 	bundle exec ruby tests/test_all.rb docker go
 

--- a/compiled_starters/git-starter-kotlin/README.md
+++ b/compiled_starters/git-starter-kotlin/README.md
@@ -1,0 +1,61 @@
+This is a starting point for Kotlin solutions to the
+["Build Your Own Git" Challenge](https://codecrafters.io/challenges/git).
+
+In this challenge, you'll build a small Git implementation that's capable of
+initializing a repository, creating commits and cloning a public repository.
+Along the way we'll learn about the `.git` directory, Git objects (blobs,
+commits, trees etc.), Git's transfer protocols and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to signup for early access.
+
+# Usage
+
+1. Ensure you have `kotlin` installed locally
+1. Run `./your_git.sh` to run your Git implementation, which is implemented in
+   `app/main.kt`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Testing locally
+
+The `your_git.sh` script is expected to operate on the `.git` folder inside the
+current working directory. If you're running this inside the root of this
+repository, you might end up accidentally damaging your repository's `.git`
+folder.
+
+We suggest executing `your_git.sh` in a different folder when testing locally.
+For example:
+
+```sh
+mkdir -p /tmp/testing && cd /tmp/testing
+/path/to/your/repo/your_git.sh init
+```
+
+To make this easier to type out, you could add a
+[shell alias](https://shapeshed.com/unix-alias/):
+
+```sh
+alias mygit=/path/to/your/repo/your_git.sh
+
+mkdir -p /tmp/testing && cd /tmp/testing
+mygit init
+```
+
+# Passing the first stage
+
+CodeCrafters runs tests when you do a `git push`. Make an empty commit and push
+your solution to see the first stage fail.
+
+```sh
+git commit --allow-empty -m "Running tests"
+git push origin master
+```
+
+You should see a failure message that says the `.git` directory wasn't
+initialized.
+
+Go to `app/main.kt` and uncomment the implementation for the `init` command.
+Commit and push your changes to pass the first stage.
+
+Time to move on to the next stage!

--- a/compiled_starters/git-starter-kotlin/app/main.kt
+++ b/compiled_starters/git-starter-kotlin/app/main.kt
@@ -1,0 +1,18 @@
+import java.io.File
+
+fun main(args: Array<String>) {
+    println("Your code goes here!")
+
+//    Uncomment this block to pass the first stage
+//
+//    when (args[0]) {
+//        "init" -> {
+//            listOf(".git", ".git/objects", ".git/refs").forEach { File(it).mkdir() }
+//            File(".git/HEAD").writeText("ref: refs/heads/master\n")
+//            println("Initialized git directory")
+//        }
+//
+//        else -> throw IllegalArgumentException("Unknown command: ${args[1]}")
+//    }
+}
+

--- a/compiled_starters/git-starter-kotlin/app/main.kt
+++ b/compiled_starters/git-starter-kotlin/app/main.kt
@@ -12,7 +12,7 @@ fun main(args: Array<String>) {
 //            println("Initialized git directory")
 //        }
 //
-//        else -> throw IllegalArgumentException("Unknown command: ${args[1]}")
+//        else -> throw IllegalArgumentException("Unknown command: ${args[0]}")
 //    }
 }
 

--- a/compiled_starters/git-starter-kotlin/codecrafters.yml
+++ b/compiled_starters/git-starter-kotlin/codecrafters.yml
@@ -4,7 +4,7 @@
 # unless you really need them.
 debug: false
 
-# Use this to change the Python version used to run your code
+# Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
 # Available versions: kotlin-1.3.72

--- a/compiled_starters/git-starter-kotlin/codecrafters.yml
+++ b/compiled_starters/git-starter-kotlin/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Python version used to run your code
+# on Codecrafters.
+#
+# Available versions: kotlin-1.3.72
+language_pack: kotlin-1.3.72

--- a/compiled_starters/git-starter-kotlin/your_git.sh
+++ b/compiled_starters/git-starter-kotlin/your_git.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-tmpFile=$(mktemp tmp.XXXXXXXXXX.jar)
+tmpFile=$(mktemp --suffix=.jar)
 kotlinc "$(dirname $0)/app/main.kt" -include-runtime -d "$tmpFile"
-kotlin -classpath "$tmpFile" MainKt "$@"
-
-rm "$tmpFile"
+exec kotlin -classpath "$tmpFile" MainKt "$@"

--- a/compiled_starters/git-starter-kotlin/your_git.sh
+++ b/compiled_starters/git-starter-kotlin/your_git.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+tmpFile=$(mktemp tmp.XXXXXXXXXX.jar)
+kotlinc "$(dirname $0)/app/main.kt" -include-runtime -d "$tmpFile"
+kotlin -classpath "$tmpFile" MainKt "$@"
+
+rm "$tmpFile"

--- a/dockerfiles/git/kotlin-1.3.72.Dockerfile
+++ b/dockerfiles/git/kotlin-1.3.72.Dockerfile
@@ -1,0 +1,4 @@
+FROM zenika/kotlin:1.3.72-jdk11-slim
+
+COPY . /app
+WORKDIR /app

--- a/starter_templates/codecrafters.yml
+++ b/starter_templates/codecrafters.yml
@@ -39,3 +39,7 @@ language_pack: rust-1.43
 # Available versions: haskell-8.8
 language_pack: haskell-8.8
 {{/ language_is_haskell }}
+{{# language_is_kotlin }}
+# Available versions: kotlin-1.3.72
+language_pack: kotlin-1.3.72
+{{/ language_is_kotlin }}

--- a/starter_templates/git/kotlin/app/main.kt
+++ b/starter_templates/git/kotlin/app/main.kt
@@ -1,0 +1,18 @@
+import java.io.File
+
+fun main(args: Array<String>) {
+    println("Your code goes here!")
+
+//    Uncomment this block to pass the first stage
+//
+//    when (args[0]) {
+//        "init" -> {
+//            listOf(".git", ".git/objects", ".git/refs").forEach { File(it).mkdir() }
+//            File(".git/HEAD").writeText("ref: refs/heads/master\n")
+//            println("Initialized git directory")
+//        }
+//
+//        else -> throw IllegalArgumentException("Unknown command: ${args[1]}")
+//    }
+}
+

--- a/starter_templates/git/kotlin/app/main.kt
+++ b/starter_templates/git/kotlin/app/main.kt
@@ -12,7 +12,7 @@ fun main(args: Array<String>) {
 //            println("Initialized git directory")
 //        }
 //
-//        else -> throw IllegalArgumentException("Unknown command: ${args[1]}")
+//        else -> throw IllegalArgumentException("Unknown command: ${args[0]}")
 //    }
 }
 

--- a/starter_templates/git/kotlin/your_git.sh
+++ b/starter_templates/git/kotlin/your_git.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-tmpFile=$(mktemp tmp.XXXXXXXXXX.jar)
+tmpFile=$(mktemp --suffix=.jar)
 kotlinc "$(dirname $0)/app/main.kt" -include-runtime -d "$tmpFile"
-kotlin -classpath "$tmpFile" MainKt "$@"
-
-rm "$tmpFile"
+exec kotlin -classpath "$tmpFile" MainKt "$@"

--- a/starter_templates/git/kotlin/your_git.sh
+++ b/starter_templates/git/kotlin/your_git.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+tmpFile=$(mktemp tmp.XXXXXXXXXX.jar)
+kotlinc "$(dirname $0)/app/main.kt" -include-runtime -d "$tmpFile"
+kotlin -classpath "$tmpFile" MainKt "$@"
+
+rm "$tmpFile"

--- a/template_compiler/definitions.rb
+++ b/template_compiler/definitions.rb
@@ -11,6 +11,7 @@ c = Language.new(slug: "c", name: "C", repo_suffix: "c")
 ruby = Language.new(slug: "ruby", name: "Ruby", repo_suffix: "ruby")
 rust = Language.new(slug: "rust", name: "Rust", repo_suffix: "rust")
 haskell = Language.new(slug: "haskell", name: "Haskell", repo_suffix: "haskell")
+kotlin = Language.new(slug: "kotlin", name: "Kotlin", repo_suffix: "kotlin")
 
 DEFINITIONS = [
   # ------------------- REDIS ------------------------------
@@ -183,5 +184,19 @@ DEFINITIONS = [
       "user_editable_file": "src/main.rs"
     }
   ),
+  Repo.new(
+    course: git,
+    language: kotlin,
+    file_mappings: [
+      FM.new("README.md", "git/README.md"),
+      FM.new("codecrafters.yml", "codecrafters.yml"),
+      FM.new("app/main.kt", "git/kotlin/app/main.kt"),
+      FM.new("your_git.sh", "git/kotlin/your_git.sh", is_executable=true),
+    ],
+    template_attrs: {
+      "required_executable": "kotlin",
+      "user_editable_file": "app/main.kt"
+    }
+  )
 
 ]

--- a/tests/starter_code_uncommenter.rb
+++ b/tests/starter_code_uncommenter.rb
@@ -53,7 +53,8 @@ class StarterCodeUncommenter
       "ruby" => "rb",
       "c" => "c",
       "rust" => "rs",
-      "haskell" => "hs"
+      "haskell" => "hs",
+      "kotlin" => "kt"
     }.fetch(language)
   end
 end

--- a/tests/test_all.rb
+++ b/tests/test_all.rb
@@ -6,6 +6,8 @@ require_relative "starter_repo_tester"
 course_filter = ARGV[0]
 language_filter = ARGV[1]
 
+puts "Course Filter:#{course_filter}, Language Filter:#{language_filter}"
+
 dockerfile_testers = Dir["dockerfiles/**/*.Dockerfile"].map do |path| 
   DockerfileTester.from_dockerfile(path)
 end

--- a/tests/test_all.rb
+++ b/tests/test_all.rb
@@ -6,8 +6,6 @@ require_relative "starter_repo_tester"
 course_filter = ARGV[0]
 language_filter = ARGV[1]
 
-puts "Course Filter:#{course_filter}, Language Filter:#{language_filter}"
-
 dockerfile_testers = Dir["dockerfiles/**/*.Dockerfile"].map do |path| 
   DockerfileTester.from_dockerfile(path)
 end

--- a/tests/uncommenter.rb
+++ b/tests/uncommenter.rb
@@ -17,7 +17,8 @@ class Uncommenter
     "go" => DOUBLE_SLASHES,
     "c" => DOUBLE_SLASHES,
     "rust" => DOUBLE_SLASHES,
-    "haskell" => DOUBLE_HYPHENS
+    "haskell" => DOUBLE_HYPHENS,
+    "kotlin" => DOUBLE_SLASHES
   }
 
   attr_reader :language, :code, :uncomment_marker_pattern


### PR DESCRIPTION
Adding in language support for Kotlin 1.3.72 in Git. For the time being, I'm pulling a slim docker image that uses this docker image target for OpenJDK 11 for convenience. Sorry to the folks that are using older versions... get with the times :-)!