### PR TITLE
Use python3 in your_git.sh script

### DIFF
--- a/compiled_starters/git-starter-python/your_git.sh
+++ b/compiled_starters/git-starter-python/your_git.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-PYTHONPATH=$(dirname $0) exec python -m app.main "$@"
+PYTHONPATH=$(dirname $0) exec python3 -m app.main "$@"

--- a/starter_templates/git/python/your_git.sh
+++ b/starter_templates/git/python/your_git.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-PYTHONPATH=$(dirname $0) exec python -m app.main "$@"
+PYTHONPATH=$(dirname $0) exec python3 -m app.main "$@"


### PR DESCRIPTION
- Why this change is needed?
When `python3` isn't set as the default python interpreter,
the script, `your_git.sh` would fail to execute as the template
code uses `python3` specific syntax.