### PR TITLE
remove extra disconnect block from javascript starter

### DIFF
--- a/compiled_starters/redis-starter-javascript/app/main.js
+++ b/compiled_starters/redis-starter-javascript/app/main.js
@@ -8,11 +8,3 @@ console.log("Your code goes here!");
 // });
 //
 // server.listen(6379, '127.0.0.1');
-//
-// server.on('request', request => {
-//   const connection = request.accept(null, request.origin);
-//
-//   connection.on('close',() => {
-//     console.log('Client has disconnected.');
-//   });
-// });

--- a/starter_templates/redis/javascript/app/main.js
+++ b/starter_templates/redis/javascript/app/main.js
@@ -8,11 +8,3 @@ console.log("Your code goes here!");
 // });
 //
 // server.listen(6379, '127.0.0.1');
-//
-// server.on('request', request => {
-//   const connection = request.accept(null, request.origin);
-//
-//   connection.on('close',() => {
-//     console.log('Client has disconnected.');
-//   });
-// });


### PR DESCRIPTION
I don't see "request" listed as a valid event. Also, we don't add disconnect logs in any other starter repo - so this is probably safe to remove!