### PR TITLE
fix: Parsing root_page column of schema

### DIFF
--- a/compiled_starters/sqlite-starter-rust/src/schema.rs
+++ b/compiled_starters/sqlite-starter-rust/src/schema.rs
@@ -3,7 +3,7 @@ pub struct Schema {
     kind: String,
     name: String,
     table_name: String,
-    root_page: u8,
+    root_page: usize,
     sql: String,
 }
 
@@ -14,16 +14,27 @@ impl Schema {
         let kind = items.next()?;
         let name = items.next()?;
         let table_name = items.next()?;
-        let root_page = *items.next()?.get(0)?;
+        let root_page = items.next()?;
         let sql = items.next()?;
 
         let schema = Self {
             kind: String::from_utf8_lossy(&kind).to_string(),
             name: String::from_utf8_lossy(&name).to_string(),
             table_name: String::from_utf8_lossy(&table_name).to_string(),
-            root_page,
+            root_page: parse_number(&root_page),
             sql: String::from_utf8_lossy(&sql).to_string(),
         };
         Some(schema)
     }
+}
+
+/// parses variable size unsigned integer encoded as bytes to number.
+fn parse_number(bytes: &[u8]) -> usize {
+    let mut result: usize = 0;
+    let num_bytes = bytes.len();
+    for i in 0..num_bytes {
+        let shift = (num_bytes - i - 1) * 8;
+        result += (bytes[i] as usize) << shift;
+    }
+    result
 }

--- a/starter_templates/sqlite/rust/src/schema.rs
+++ b/starter_templates/sqlite/rust/src/schema.rs
@@ -3,7 +3,7 @@ pub struct Schema {
     kind: String,
     name: String,
     table_name: String,
-    root_page: u8,
+    root_page: usize,
     sql: String,
 }
 
@@ -14,16 +14,27 @@ impl Schema {
         let kind = items.next()?;
         let name = items.next()?;
         let table_name = items.next()?;
-        let root_page = *items.next()?.get(0)?;
+        let root_page = items.next()?;
         let sql = items.next()?;
 
         let schema = Self {
             kind: String::from_utf8_lossy(&kind).to_string(),
             name: String::from_utf8_lossy(&name).to_string(),
             table_name: String::from_utf8_lossy(&table_name).to_string(),
-            root_page,
+            root_page: parse_number(&root_page),
             sql: String::from_utf8_lossy(&sql).to_string(),
         };
         Some(schema)
     }
+}
+
+/// parses variable size unsigned integer encoded as bytes to number.
+fn parse_number(bytes: &[u8]) -> usize {
+    let mut result: usize = 0;
+    let num_bytes = bytes.len();
+    for i in 0..num_bytes {
+        let shift = (num_bytes - i - 1) * 8;
+        result += (bytes[i] as usize) << shift;
+    }
+    result
 }


### PR DESCRIPTION
`root_page` was parsed as `u8` which is not correct as according to docs:
"The maximum page number is 4294967294"
https://www.sqlite.org/fileformat2.html#pages

It could fit in `u32` but since the bytes slice length is variable anyway
we parse it to `usize` for convenience.

The issue did non manifest often as root pages of tables and indexes
were usually at the front, it however caused issues when running
against full `companies.db`.