### PR TITLE
Update Rust Docker image to 1.62-buster for starter template

### DIFF
--- a/compiled_starters/docker-starter-rust/Dockerfile
+++ b/compiled_starters/docker-starter-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54-buster
+FROM rust:1.62-buster
 
 # Download docker-explorer
 ARG docker_explorer_version=v18

--- a/starter_templates/docker/rust/Dockerfile
+++ b/starter_templates/docker/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54-buster
+FROM rust:1.62-buster
 
 # Download docker-explorer
 ARG docker_explorer_version=v18


### PR DESCRIPTION
I got stuck on stage 2 of the Docker challenge using Rust. I suspect the updated dependencies in [this commit](https://github.com/codecrafters-io/languages/commit/7c5236ac87476e36f5c76f3fda251cb4f06db95b) could have broken the build.

Error log for Docker image `rust:1.54-buster`
```
mydocker run ubuntu:latest /usr/local/bin/docker-explorer echo hey
[+] Building 24.8s (13/15)
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 37B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/rust:1.54-buster                                                                                0.6s
 => [ 1/11] FROM docker.io/library/rust:1.54-buster@sha256:89553adaae134c09ac87eee3b14b5e5d53862d5bed9cbbd549b4815696767622                        0.0s
 => [internal] load build context                                                                                                                  0.2s
 => => transferring context: 894.39kB                                                                                                              0.2s
 => CACHED [ 2/11] RUN curl --fail -Lo /usr/local/bin/docker-explorer https://github.com/codecrafters-io/docker-explorer/releases/download/v18/v1  0.0s
 => CACHED [ 3/11] RUN chmod +x /usr/local/bin/docker-explorer                                                                                     0.0s
 => CACHED [ 4/11] COPY Cargo.toml /app/Cargo.toml                                                                                                 0.0s
 => CACHED [ 5/11] COPY Cargo.lock /app/Cargo.lock                                                                                                 0.0s
 => CACHED [ 6/11] RUN mkdir /app/src                                                                                                              0.0s
 => CACHED [ 7/11] RUN echo 'fn main() { println!("Hello World!"); }' > /app/src/main.rs                                                           0.0s
 => CACHED [ 8/11] WORKDIR /app                                                                                                                    0.0s
 => ERROR [ 9/11] RUN cargo build --release --target-dir=/tmp/codecrafters-docker-target                                                          23.9s
------
 > [ 9/11] RUN cargo build --release --target-dir=/tmp/codecrafters-docker-target:
#13 0.876     Updating crates.io index
#13 18.01  Downloading crates ...
#13 23.76   Downloaded socket2 v0.3.19
#13 23.81   Downloaded tokio v0.2.25
#13 23.85   Downloaded tracing-futures v0.2.5
#13 23.85   Downloaded tracing v0.1.36
#13 23.85   Downloaded tower-service v0.3.2
#13 23.85   Downloaded version_check v0.9.4
#13 23.86   Downloaded lazy_static v1.4.0
#13 23.86   Downloaded mime v0.3.16
#13 23.86   Downloaded unicase v2.6.0
#13 23.86   Downloaded http v0.2.8
#13 23.87   Downloaded log v0.4.17
#13 23.87   Downloaded openssl-sys v0.9.75
#13 23.87   Downloaded try-lock v0.2.3
#13 23.87   Downloaded pkg-config v0.3.25
#13 23.87   Downloaded pin-project v1.0.11
#13 23.89   Downloaded ryu v1.0.11
#13 23.90   Downloaded tokio-tls v0.3.1
#13 23.90   Downloaded fnv v1.0.7
#13 23.90   Downloaded httparse v1.7.1
#13 23.90   Downloaded indexmap v1.9.1
#13 23.91 error: failed to parse manifest at `/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.1/Cargo.toml`
#13 23.91
#13 23.91 Caused by:
#13 23.91   feature `edition2021` is required
#13 23.91
#13 23.91   this Cargo does not support nightly features, but if you
#13 23.91   switch to nightly channel you can add
#13 23.91   `cargo-features = ["edition2021"]` to enable this feature
------
executor failed running [/bin/sh -c cargo build --release --target-dir=/tmp/codecrafters-docker-target]: exit code: 101
```

After updating to Docker image `rust:1.62-buster`
```
mydocker run ubuntu:latest /usr/local/bin/docker-explorer echo hey
[+] Building 104.3s (16/16) FINISHED
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 825B                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/rust:1.62-buster                                                                                1.8s
 => [ 1/11] FROM docker.io/library/rust:1.62-buster@sha256:56096342794fc37a4e9764a45a240ed9157871d9fbb287f730962932159b74fd                       17.5s
 => => resolve docker.io/library/rust:1.62-buster@sha256:56096342794fc37a4e9764a45a240ed9157871d9fbb287f730962932159b74fd                          0.0s
 => => sha256:0016ef4e65e361472962c2982a7bcfa4778f2fcb1b570b4d898c8bbc8169b1c8 1.59kB / 1.59kB                                                     0.0s
 => => sha256:85771b333c80cfac988bb70a211ff786120e28a3881f33c00d9ef2f55a1ae00f 6.43kB / 6.43kB                                                     0.0s
 => => sha256:e31ca5ccee8fca6610f14b5ed35ac33bb5f545532b6583e1461037a083c3d87b 7.72MB / 7.72MB                                                     0.5s
 => => sha256:56096342794fc37a4e9764a45a240ed9157871d9fbb287f730962932159b74fd 988B / 988B                                                         0.0s
 => => sha256:71209d5eb534b9e48223962276993c68559f68e230f73c8a0efc2a2998362bd9 49.23MB / 49.23MB                                                   1.4s
 => => sha256:32de8e1f96ccb825d3be85704be7218044a19ff05ea1eea0222e8c942fbf6f8f 9.77MB / 9.77MB                                                     1.0s
 => => sha256:965555a6fd3b7a1727fd927269ea37139a09652f2545ea1c825b36af887f2713 52.18MB / 52.18MB                                                   1.9s
 => => sha256:0a9f74159765153bc30ad454581950cf261ea197c10a3a9e9faeee4095c1d2dd 184.09MB / 184.09MB                                                 4.7s
 => => sha256:286438798c6c85c29ae48c02e676aa1c2189905a71dd10e1de2e6c7da5a248de 209.30MB / 209.30MB                                                 6.5s
 => => extracting sha256:71209d5eb534b9e48223962276993c68559f68e230f73c8a0efc2a2998362bd9                                                          2.8s
 => => extracting sha256:e31ca5ccee8fca6610f14b5ed35ac33bb5f545532b6583e1461037a083c3d87b                                                          0.3s
 => => extracting sha256:32de8e1f96ccb825d3be85704be7218044a19ff05ea1eea0222e8c942fbf6f8f                                                          0.2s
 => => extracting sha256:965555a6fd3b7a1727fd927269ea37139a09652f2545ea1c825b36af887f2713                                                          1.8s
 => => extracting sha256:0a9f74159765153bc30ad454581950cf261ea197c10a3a9e9faeee4095c1d2dd                                                          4.4s
 => => extracting sha256:286438798c6c85c29ae48c02e676aa1c2189905a71dd10e1de2e6c7da5a248de                                                          5.8s
 => [internal] load build context                                                                                                                  0.1s
 => => transferring context: 218.00kB                                                                                                              0.1s
 => [ 2/11] RUN curl --fail -Lo /usr/local/bin/docker-explorer https://github.com/codecrafters-io/docker-explorer/releases/download/v18/v18_linux  1.0s
 => [ 3/11] RUN chmod +x /usr/local/bin/docker-explorer                                                                                            0.4s
 => [ 4/11] COPY Cargo.toml /app/Cargo.toml                                                                                                        0.0s
 => [ 5/11] COPY Cargo.lock /app/Cargo.lock                                                                                                        0.0s
 => [ 6/11] RUN mkdir /app/src                                                                                                                     0.3s
 => [ 7/11] RUN echo 'fn main() { println!("Hello World!"); }' > /app/src/main.rs                                                                  0.4s
 => [ 8/11] WORKDIR /app                                                                                                                           0.0s
 => [ 9/11] RUN cargo build --release --target-dir=/tmp/codecrafters-docker-target                                                                79.0s
 => [10/11] RUN cargo clean -p docker-starter-rust --release --target-dir=/tmp/codecrafters-docker-target                                          0.5s
 => [11/11] ADD . /app                                                                                                                             1.2s
 => exporting to image                                                                                                                             2.1s
 => => exporting layers                                                                                                                            2.1s
 => => writing image sha256:89cd65ae6097b63626947ee0b07548fba679523bd4494e408494c28c9d556198                                                       0.0s
 => => naming to docker.io/library/mydocker                                                                                                        0.0s
hey
```